### PR TITLE
restart: fix rebooting to bootloader

### DIFF
--- a/arch/arm/mach-msm/restart.c
+++ b/arch/arm/mach-msm/restart.c
@@ -293,7 +293,7 @@ static void msm_restart_prepare(const char *cmd)
 
 	if (cmd != NULL) {
 		if (!strncmp(cmd, "bootloader", 10)) {
-			__raw_writel(0x77665500, restart_reason);
+			__raw_writel(0x6C616664, restart_reason);
 		} else if (!strncmp(cmd, "recovery", 8)) {
 			__raw_writel(0x77665502, restart_reason);
 		} else if (!strncmp(cmd, "adbrecovery", 11)) {


### PR DESCRIPTION
- needs moar http://tinyw.in/q88S

Change-Id: I2999b12728e741b11f3d4c588df2f99927aa156b

It should fix "reboot to bootloader" function - reboot device to download mode
